### PR TITLE
imguiplotconfig: add header <limits>

### DIFF
--- a/include/imguiplotconfig.h
+++ b/include/imguiplotconfig.h
@@ -17,10 +17,10 @@
 #ifndef imguiplot_imguiplotconfig_h
 #define imguiplot_imguiplotconfig_h
 
+#include <imgui.h>
+#include <limits>
 #include <string>
 #include <vector>
-
-#include <imgui.h>
 
 /**
  * \brief The Anti aliasing behaviour of a plot


### PR DESCRIPTION
This PR adds the header <limits> to imguiplotconfig, which defines numeric_limits. The default behaviour, whether <limits> is included by another header already seems to be platform/compiler dependent. This is required for building on my system (Arch Linux, GCC 10.1)